### PR TITLE
Feature/radix layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,13 @@
-function App() {
-  return (
-    <>
-      <h1>Hello World!</h1>
-    </>
-  )
-}
+import React from "react";
+import Layout from "@/components/layout/Layout";
 
-export default App
+/**
+ * The root App component simply renders the Layout. The actual application
+ * structure lives in the Layout component, which composes the header,
+ * sidebar and tabbed main content area. Keeping the App component
+ * minimal makes it easier for new developers to understand where
+ * high‑level structure is defined.
+ */
+export default function App() {
+  return <Layout />;
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+} from "@/components/ui/avatar";
+
+/**
+ * A simple application header. It displays the app name on the left and a
+ * user avatar with a dropdown menu on the right. The dropdown menu uses
+ * Radix primitives wrapped by our shadcn/ui components for consistent
+ * styling and behavior. In a real app you could replace the avatar
+ * fallback and image with user data.
+ */
+export default function Header() {
+  return (
+    <header className="bg-background border-b flex items-center justify-between px-4 py-3">
+      <h1 className="text-xl font-semibold">Expense App</h1>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="focus:outline-none rounded-full">
+            <Avatar>
+              {/* In a real application this image could come from user profile data */}
+              <AvatarImage
+                src="https://avatars.githubusercontent.com/u/1?v=4"
+                alt="User avatar"
+              />
+              <AvatarFallback>UA</AvatarFallback>
+            </Avatar>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuItem>Profile</DropdownMenuItem>
+          <DropdownMenuItem>Settings</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Logout</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </header>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import Overview from "@/pages/Overview";
+import Reports from "@/pages/Reports";
+
+export default function Layout() {
+  return (
+    <div className="min-h-screen bg-background text-foreground flex flex-col">
+      <Header />
+      <div className="flex flex-1">
+        <Sidebar />
+        <main className="flex-1 p-6">
+          <Tabs defaultValue="overview" className="w-full">
+            <TabsList>
+              <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="reports">Reports</TabsTrigger>
+            </TabsList>
+            <TabsContent value="overview">
+              <Overview />
+            </TabsContent>
+            <TabsContent value="reports">
+              <Reports />
+            </TabsContent>
+          </Tabs>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
+
+/**
+ * A simple sidebar built with Radix Accordion. Each accordion section
+ * represents a category of navigation links. This sidebar can be easily
+ * expanded with additional items or nested accordions. To keep things
+ * generic and scalable, the links are just anchors for now. In a more
+ * complex application you might hook these up to a router or update
+ * application state when clicked.
+ */
+export default function Sidebar() {
+  return (
+    <aside className="bg-background border-r w-60 p-4">
+      <Accordion type="single" collapsible defaultValue="general">
+        <AccordionItem value="general">
+          <AccordionTrigger className="text-sm">General</AccordionTrigger>
+          <AccordionContent>
+            <ul className="pl-4 space-y-2">
+              <li>
+                <a href="#overview" className="text-sm hover:underline text-foreground">
+                  Overview
+                </a>
+              </li>
+              <li>
+                <a href="#transactions" className="text-sm hover:underline text-foreground">
+                  Transactions
+                </a>
+              </li>
+            </ul>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="reports">
+          <AccordionTrigger className="text-sm">Reports</AccordionTrigger>
+          <AccordionContent>
+            <ul className="pl-4 space-y-2">
+              <li>
+                <a href="#monthly" className="text-sm hover:underline text-foreground">
+                  Monthly
+                </a>
+              </li>
+              <li>
+                <a href="#yearly" className="text-sm hover:underline text-foreground">
+                  Yearly
+                </a>
+              </li>
+            </ul>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </aside>
+  );
+}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+
+export default function Overview() {
+  return (
+    <div className="p-4 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Monthly Spending</CardTitle>
+          <CardDescription>Track your spending against your monthly budget</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p className="text-sm text-muted-foreground">You've spent $350 of your $500 budget.</p>
+          <Progress value={70} />
+        </CardContent>
+      </Card>
+      {/* Additional overview sections can be added here */}
+    </div>
+  );
+}

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export default function Reports() {
+  return (
+    <div className="p-4 space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Reports</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">Detailed reports will be available soon.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a scalable layout using Radix UI components and shadcn-styled elements.

**Key changes:**
- Added reusable `Header`, `Sidebar`, and `Layout` components under `src/components/layout`.
  - The header includes a dropdown menu with user actions.
  - The sidebar uses accordion sections for navigation links.
  - The layout composes the header and sidebar and adds a tabbed main area using Radix `Tabs`.
- Created new pages:
  - `src/pages/Overview.tsx`: displays a monthly spending card with a progress bar.
  - `src/pages/Reports.tsx`: placeholder page for detailed reports.
- Updated `App.tsx` to render the new `Layout` component.

These changes provide a clear structure for new developers and demonstrate how to integrate Radix primitives and shadcn UI for consistent styling and behavior.