### PR TITLE
Add GitHub Pages deployment workflow using Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy to GitHub Pages
+
+# This workflow will build the Vite application and publish it to GitHub Pages.
+# It uses the official upload‑pages and deploy‑pages actions, following GitHub's
+# recommended setup for static site deployments.  The site will be hosted at
+# `https://jaiminmoslake7020.github.io/expense-app/`.
+
+on:
+  # Rebuild and deploy when changes land on the default branch.
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'github-pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build Vite app
+        # Pass the base path so that assets resolve correctly when served from a subpath.
+        run: npm run build -- --base=/expense-app/
+      - name: Upload build artifacts
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build and deploy the Vite-based expense app to GitHub Pages. It sets up Node, installs dependencies, runs the build with the proper base path, and deploys the generated `dist` folder to GitHub Pages.